### PR TITLE
Restructurize matching around directives

### DIFF
--- a/bean_check.sublime-build
+++ b/bean_check.sublime-build
@@ -1,5 +1,6 @@
 {
     "cmd": ["bean-check", "$file"],
     "file_regex": "^((?:/[^/]+)*):(\\d*):(\\s*)(.+)",
-    "selector": "source.beancount"
+    "selector": "source.beancount",
+    "path": "$PATH:$HOME/bin:$HOME/.local/bin"
 }

--- a/beancount.YAML-tmLanguage
+++ b/beancount.YAML-tmLanguage
@@ -4,13 +4,12 @@ scopeName: source.beancount
 fileTypes: [beancount]
 uuid: dbf28879-ee4d-497e-a678-a5c5a5e8d74f
 
-
 patterns:
 - comment: Comments
   name: comment.line.beancount
   match:  ;.*
 
-- comment: Tag directive (no date, no string, tag, no meta, no ops)
+- comment: Tag directive
   name: meta.directive.tag.beancount
   match: ^(poptag|pushtag)\s+(#)([A-Za-z0-9\-_/.]+)\s*\n
   captures:
@@ -18,38 +17,14 @@ patterns:
     '2': {name: keyword.operator.tag.beancount}
     '3': {name: string.unquoted.tag.beancount}
 
-- comment: Include directive (no date, string x1, no tag, no meta, no ops)
+- comment: Include directive
   name: meta.directive.include.beancount
   match: ^(include)\s+(\".*\")\s*\n
   captures:
     '1': {name: keyword.operator.directive.beancount}
     '2': {name: string.quoted.double.beancount}
 
-- comment: Account
-  begin: ([A-Z][A-Za-z0-9\-]+)(:)
-  beginCaptures:
-    '1': {name: constant.language.beancount}
-    '2': {name: punctuation.separator.beancount}
-  patterns:
-  - comment: Sub accounts
-    begin: ([A-Z][A-Za-z0-9\-]+)([:]?)
-    beginCaptures:
-      '1': {name: variable.account.beancount}
-      '2': {name: punctuation.separator.beancount}
-    patterns:
-    - {include: '$self'}
-    end: ([:]?)|(\s)
-  end: \s
-
-- comment: strings
-  name: string.quoted.double.beancount
-  begin: \"
-  patterns:
-  - name: constant.character.escape.beancount
-    match: \\.
-  end: \"
-
-- comment: Option directive (no date, string x2, no tag, no meta, no ops)
+- comment: Option directive
   name: meta.directive.option.beancount
   match: ^(option)\s+(\".*\")\s+(\".*\")\s*\n
   captures:
@@ -57,7 +32,7 @@ patterns:
     '2': {name: support.variable.language.option.beancount}
     '3': {name: string.quoted.double.beancount}
 
-- comment: Plugin directive (no date, string x2, no tag, no meta, no ops)
+- comment: Plugin directive
   name: keyword.operator.directive.beancount
   match: ^(plugin)\s+(\"(.*)\")\s+(\".*\")\s*\n
   captures:
@@ -67,7 +42,7 @@ patterns:
     '4': {name: string.quoted.double.beancount}
 
 # FIXME: Restrict use of account too many times
-- comment: Open/Close/Pad directive (date, account, no tag, meta?)
+- comment: Open/Close/Pad directive
   name: meta.directive.dated.beancount
   begin: ([0-9]{4})[\-|/]([0-9]{2})[\-|/]([0-9]{2})\s(open|close|pad)
   beginCaptures:
@@ -78,10 +53,10 @@ patterns:
   patterns:
   - include: '#account'
   - include: '#meta'
-  end: ^(?!\s)
+  end: (?=(^\s*$|^\S))
 
 # FIXME: Restrict use of string too many times
-- comment: Event directive (date, string, no tag, meta?)
+- comment: Event directive
   name: meta.directive.dated.beancount
   begin: ([0-9]{4})[\-|/]([0-9]{2})[\-|/]([0-9]{2})\s(event)
   beginCaptures:
@@ -92,10 +67,10 @@ patterns:
   patterns:
   - include: '#string'
   - include: '#meta'
-  end: ^(?!\s)
+  end: (?=(^\s*$|^\S))
 
 # FIXME: Restrict use of commodity too many times
-- comment: Commodity directive (date, account, string, no tag, meta?)
+- comment: Commodity directive
   name: meta.directive.dated.beancount
   begin: ([0-9]{4})[\-|/]([0-9]{2})[\-|/]([0-9]{2})\s(commodity)
   beginCaptures:
@@ -106,10 +81,10 @@ patterns:
   patterns:
   - include: '#commodity'
   - include: '#meta'
-  end: ^(?!\s)
+  end: (?=(^\s*$|^\S))
 
 # FIXME: Restrict use of account and string too many times
-- comment: Note/Document directive (date, account, string, no tag, meta?)
+- comment: Note/Document directive
   name: meta.directive.dated.beancount
   begin: ([0-9]{4})[\-|/]([0-9]{2})[\-|/]([0-9]{2})\s(note|document)
   beginCaptures:
@@ -121,10 +96,10 @@ patterns:
   - include: '#account'
   - include: '#string'
   - include: '#meta'
-  end: ^(?!\s)
+  end: (?=(^\s*$|^\S))
 
 # FIXME: Restrict use of commodity and amount too many times
-- comment: Price directives (date, string?, no tag, meta?)
+- comment: Price directives
   name: meta.directive.dated.beancount
   begin: ([0-9]{4})[\-|/]([0-9]{2})[\-|/]([0-9]{2})\s(price)
   beginCaptures:
@@ -136,10 +111,10 @@ patterns:
   - include: '#commodity'
   - include: '#amount'
   - include: '#meta'
-  end: ^(?!\s)
+  end: (?=(^\s*$|^\S))
 
 # FIXME: Restrict use of account and amount too many times
-- comment: Balance directives (date, string?, no tag, meta?)
+- comment: Balance directives
   name: meta.directive.dated.beancount
   begin: ([0-9]{4})[\-|/]([0-9]{2})[\-|/]([0-9]{2})\s(balance)
   beginCaptures:
@@ -151,65 +126,49 @@ patterns:
   - include: '#account'
   - include: '#amount'
   - include: '#meta'
-  end: ^(?!\s)
+  end: (?=(^\s*$|^\S))
 
-# FIXME: this violates DRY
-
-- comment: Transactions
-  match: ([0-9]{4}[\-|/][0-9]{2}[\-|/][0-9]{2})\s((txn)|\*|\!)\s(".*?")(\s+".*?")?((\s*#[a-zA-z\-]+)*)(\s*;.*)?
-  captures:
-    '1': {name: constant.numeric.date.beancount}
-    '2': {name: support.function.directive.beancount}
-    '4': {name: string.quoted.tiers.beancount}
-    '5': {name: string.quoted.narration.beancount}
-    '6': {name: keyword.operator.tags.beancount}
-    '8': {name: comment.line.beancount}
-
-
-- comment: flag
-  name: keyword.other.beancount
-  match: \s\!
-
-- comment: Price assignment
-  name: keyword.operator.assignment.beancount
-  match: \@
-
-
-- comment: cost assignment
-  begin: (\{)
+- comment: Transaction directive
+  name: meta.directive.transaction.beancount
+  begin: ([0-9]{4})([\-|/])([0-9]{2})([\-|/])([0-9]{2})\s+(txn|\*|\!)(?:\s+(".*")(?=\s+"))?\s+(".*?")(?=((?:\s+#[a-zA-z\-]+(?=\s))*(?:\s+\^[a-zA-z\-\.]+(?=\s))*(?:\s+;\s*.*)?)\s)
   beginCaptures:
-    '1': {name: keyword.operator.assignment.beancount}
+    '1': {name: constant.numeric.date.year.beancount}
+    '2': {name: punctuation.separator.beancount}
+    '3': {name: constant.numeric.date.month.beancount}
+    '4': {name: punctuation.separator.beancount}
+    '5': {name: constant.numeric.date.day.beancount}
+    '6': {name: support.function.directive.beancount}
+    '7': {name: string.quoted.tiers.beancount}
+    '8': {name: string.quoted.narration.beancount}
   patterns:
-  - name: keyword.operator.assignment.beancount
-    match:  \/
-  end: (\})
-  endCaptures:
-    '1': {name: keyword.operator.assignment.beancount}
+  - include: '#tag'
+  - include: '#link'
+  - include: '#comment'
+  - include: '#meta'
+  - include: '#posting'
+  end: (?=(^\s*$|^\S))
 
-- comment: Tags and links
-  match: (#)([A-Za-z0-9\-_/.]+)
-  captures:
-    '1': {name: keyword.operator.tag.beancount}
-    '2': {name: string.unquoted.tag.beancount}
-
-- comment: Links
-  match: (\^)([A-Za-z0-9\-_/.]+)
-  captures:
-    '2': {name: string.unquoted.link.beancount}
-
-- comment: numbers
-  match: ([\-|\+]?)([\d]+[\.]?[\d]*)\s?([A-Z][A-Z0-9\-]{0,10})
-  captures:
-    '1': {name: keyword.operator.modifier.beancount}
-    '2': {name: constant.numeric.currency.beancount}
-    '3': {name: variable.other.currency.beancount}
-
-- comment: Illegal
-  name: invalid.illegal.unrecognized.beancount
-  match: '[^\s}]'
+# - include: '#illegal'
 
 repository:
+  posting:
+    name: meta.posting.beancount
+    begin: ^\s+(?=([A-Z\!]))
+    patterns:
+    - include: '#flag'
+    - include: '#account'
+    - include: '#amount'
+    - include: '#cost'
+    - include: '#date'
+    - include: '#price'
+    - include: '#comment'
+    - include: '#illegal'
+    end: (?=\n)
+  flag:
+    name: keyword.other.beancount
+    match: (?<=\s)(\!)
   account:
+    name: meta.account.beancount
     begin: ([A-Z][A-Za-z0-9\-]+)(:)
     beginCaptures:
       '1': {name: constant.language.beancount}
@@ -224,9 +183,51 @@ repository:
       - {include: '$self'}
       end: ([:]?)|(\s)
     end: \s
+  amount:
+    name: meta.amount.beancount
+    match: ([\-|\+]?)([\d]+[\.]?[\d]*)\s*([A-Z][A-Z0-9\'\.\_\-]{0,22}[A-Z0-9])
+    captures:
+      '1': {name: keyword.operator.modifier.beancount}
+      '2': {name: constant.numeric.currency.beancount}
+      '3': {name: variable.other.currency.beancount}
+  cost:
+    name: meta.cost.beancount
+    begin: \{
+    beginCaptures:
+      '0': {name: keyword.operator.assignment.beancount}
+    patterns:
+    - include: '#date'
+    - include: '#amount'
+    end: \}
+    endCaptures:
+      '0': {name: keyword.operator.assignment.beancount}
+  price:
+    name: meta.price.beancount
+    begin: \@
+    beginCaptures:
+      '0': {name: keyword.operator.assignment.beancount}
+    patterns:
+    - include: '#amount'
+    end: (?=(;|\n))
+  date:
+    name: meta.date.beancount
+    match: ([0-9]{4})([\-|/])([0-9]{2})([\-|/])([0-9]{2})
+    captures:
+      '1': {name: constant.numeric.date.year.beancount}
+      '2': {name: punctuation.separator.beancount}
+      '3': {name: constant.numeric.date.month.beancount}
+      '4': {name: punctuation.separator.beancount}
+      '5': {name: constant.numeric.date.day.beancount}
   meta:
-    match: ^\s*([a-z][A-Za-z0-9\-]+)[:]\s
-    name: keyword.operator.directive.beancount
+    name: meta.meta.beancount
+    begin: ^\s*([a-z][A-Za-z0-9\-]+)([:])\s
+    beginCaptures:
+      '1': {name: keyword.operator.directive.beancount}
+      '2': {name: punctuation.separator.beancount}
+    patterns:
+    - include: '#string'
+    - include: '#comment'
+    end: \n
   string:
     name: string.quoted.double.beancount
     begin: \"
@@ -236,10 +237,21 @@ repository:
     end: \"
   commodity:
     name: string.unquoted.commodity.beancount
-    match: ([A-Z][A-Z0-9\-_]+)\s
-  amount:
-    match: ([\-|\+]?)([\d]+[\.]?[\d]*)\s?([A-Z][A-Z0-9\-]{0,10})
+    match: ([A-Z][A-Z0-9\'\.\_\-]{0,22}[A-Z0-9])
+  tag:
+    match: (?<=\s)(#)([A-Za-z0-9\-_/.]+)(?=\s)
     captures:
-      '1': {name: keyword.operator.modifier.beancount}
-      '2': {name: constant.numeric.currency.beancount}
-      '3': {name: variable.other.currency.beancount}
+      '1': {name: keyword.operator.tag.beancount}
+      '2': {name: entity.name.tag.beancount}
+  link:
+    match: (?<=\s)(\^)([A-Za-z0-9\-_/.]+)(?=\s)
+    captures:
+      '1': {name: keyword.operator.link.beancount}
+      '2': {name: markup.underline.link.beancount}
+  comment:
+    match: (?<=\s)(;.*)(?=\n)
+    captures:
+      '1': {name: comment.line.beancount}
+  illegal:
+    name: invalid.illegal.unrecognized.beancount
+    match: '[^\s]'

--- a/beancount.YAML-tmLanguage
+++ b/beancount.YAML-tmLanguage
@@ -6,9 +6,24 @@ uuid: dbf28879-ee4d-497e-a678-a5c5a5e8d74f
 
 
 patterns:
-- comment: Commented text
+- comment: Comments
   name: comment.line.beancount
   match:  ;.*
+
+- comment: Tag directive (no date, no string, tag, no meta, no ops)
+  name: meta.directive.tag.beancount
+  match: ^(poptag|pushtag)\s+(#)([A-Za-z0-9\-_/.]+)\s*\n
+  captures:
+    '1': {name: keyword.operator.directive.beancount}
+    '2': {name: keyword.operator.tag.beancount}
+    '3': {name: string.unquoted.tag.beancount}
+
+- comment: Include directive (no date, string x1, no tag, no meta, no ops)
+  name: meta.directive.include.beancount
+  match: ^(include)\s+(\".*\")\s*\n
+  captures:
+    '1': {name: keyword.operator.directive.beancount}
+    '2': {name: string.quoted.double.beancount}
 
 - comment: Account
   begin: ([A-Z][A-Za-z0-9\-]+)(:)
@@ -34,33 +49,111 @@ patterns:
     match: \\.
   end: \"
 
-# - comment: strings
-#   name: string.quoted.double.beancount
-#   match: \".*\"
-
-- comment: Option directives
+- comment: Option directive (no date, string x2, no tag, no meta, no ops)
   name: meta.directive.option.beancount
-  match: ^(option)\s*(\".*\")\s*(\".*\")\s*
+  match: ^(option)\s+(\".*\")\s+(\".*\")\s*\n
   captures:
     '1': {name: support.function.directive.option.beancount}
     '2': {name: support.variable.language.option.beancount}
-    '3': {name: support.class.option.beancount}
+    '3': {name: string.quoted.double.beancount}
 
-- comment: Directives (no date)
+- comment: Plugin directive (no date, string x2, no tag, no meta, no ops)
   name: keyword.operator.directive.beancount
-  match: ^(poptag|pushtag|include|plugin)\s
-
-- comment: Dated directives
-  match: ([0-9]{4})[\-|/]([0-9]{2})[\-|/]([0-9]{2})\s(open|close|pad|balance|note|price|event|document|commodity)
+  match: ^(plugin)\s+(\"(.*)\")\s+(\".*\")\s*\n
   captures:
+    '1': {name: keyword.operator.directive.beancount}
+    '2': {name: string.quoted.double.beancount}
+    '3': {name: entity.name.function.beancount}
+    '4': {name: string.quoted.double.beancount}
+
+# FIXME: Restrict use of account too many times
+- comment: Open/Close/Pad directive (date, account, no tag, meta?)
+  name: meta.directive.dated.beancount
+  begin: ([0-9]{4})[\-|/]([0-9]{2})[\-|/]([0-9]{2})\s(open|close|pad)
+  beginCaptures:
     '1': {name: constant.numeric.date.year.beancount}
     '2': {name: constant.numeric.date.month.beancount}
     '3': {name: constant.numeric.date.day.beancount}
     '4': {name: support.function.directive.beancount}
+  patterns:
+  - include: '#account'
+  - include: '#meta'
+  end: ^(?!\s)
+
+# FIXME: Restrict use of string too many times
+- comment: Event directive (date, string, no tag, meta?)
+  name: meta.directive.dated.beancount
+  begin: ([0-9]{4})[\-|/]([0-9]{2})[\-|/]([0-9]{2})\s(event)
+  beginCaptures:
+    '1': {name: constant.numeric.date.year.beancount}
+    '2': {name: constant.numeric.date.month.beancount}
+    '3': {name: constant.numeric.date.day.beancount}
+    '4': {name: support.function.directive.beancount}
+  patterns:
+  - include: '#string'
+  - include: '#meta'
+  end: ^(?!\s)
+
+# FIXME: Restrict use of commodity too many times
+- comment: Commodity directive (date, account, string, no tag, meta?)
+  name: meta.directive.dated.beancount
+  begin: ([0-9]{4})[\-|/]([0-9]{2})[\-|/]([0-9]{2})\s(commodity)
+  beginCaptures:
+    '1': {name: constant.numeric.date.year.beancount}
+    '2': {name: constant.numeric.date.month.beancount}
+    '3': {name: constant.numeric.date.day.beancount}
+    '4': {name: support.function.directive.beancount}
+  patterns:
+  - include: '#commodity'
+  - include: '#meta'
+  end: ^(?!\s)
+
+# FIXME: Restrict use of account and string too many times
+- comment: Note/Document directive (date, account, string, no tag, meta?)
+  name: meta.directive.dated.beancount
+  begin: ([0-9]{4})[\-|/]([0-9]{2})[\-|/]([0-9]{2})\s(note|document)
+  beginCaptures:
+    '1': {name: constant.numeric.date.year.beancount}
+    '2': {name: constant.numeric.date.month.beancount}
+    '3': {name: constant.numeric.date.day.beancount}
+    '4': {name: support.function.directive.beancount}
+  patterns:
+  - include: '#account'
+  - include: '#string'
+  - include: '#meta'
+  end: ^(?!\s)
+
+# FIXME: Restrict use of commodity and amount too many times
+- comment: Price directives (date, string?, no tag, meta?)
+  name: meta.directive.dated.beancount
+  begin: ([0-9]{4})[\-|/]([0-9]{2})[\-|/]([0-9]{2})\s(price)
+  beginCaptures:
+    '1': {name: constant.numeric.date.year.beancount}
+    '2': {name: constant.numeric.date.month.beancount}
+    '3': {name: constant.numeric.date.day.beancount}
+    '4': {name: support.function.directive.beancount}
+  patterns:
+  - include: '#commodity'
+  - include: '#amount'
+  - include: '#meta'
+  end: ^(?!\s)
+
+# FIXME: Restrict use of account and amount too many times
+- comment: Balance directives (date, string?, no tag, meta?)
+  name: meta.directive.dated.beancount
+  begin: ([0-9]{4})[\-|/]([0-9]{2})[\-|/]([0-9]{2})\s(balance)
+  beginCaptures:
+    '1': {name: constant.numeric.date.year.beancount}
+    '2': {name: constant.numeric.date.month.beancount}
+    '3': {name: constant.numeric.date.day.beancount}
+    '4': {name: support.function.directive.beancount}
+  patterns:
+  - include: '#account'
+  - include: '#amount'
+  - include: '#meta'
+  end: ^(?!\s)
+
 # FIXME: this violates DRY
-- comment: metadata
-  match: \s\s([a-z][A-Za-z0-9\-]+)[:]\s
-  name: keyword.operator.directive.beancount
 
 - comment: Transactions
   match: ([0-9]{4}[\-|/][0-9]{2}[\-|/][0-9]{2})\s((txn)|\*|\!)\s(".*?")(\s+".*?")?((\s*#[a-zA-z\-]+)*)(\s*;.*)?
@@ -114,3 +207,39 @@ patterns:
 - comment: Illegal
   name: invalid.illegal.unrecognized.beancount
   match: '[^\s}]'
+
+repository:
+  account:
+    begin: ([A-Z][A-Za-z0-9\-]+)(:)
+    beginCaptures:
+      '1': {name: constant.language.beancount}
+      '2': {name: punctuation.separator.beancount}
+    patterns:
+    - comment: Sub accounts
+      begin: ([A-Z][A-Za-z0-9\-]+)([:]?)
+      beginCaptures:
+        '1': {name: variable.account.beancount}
+        '2': {name: punctuation.separator.beancount}
+      patterns:
+      - {include: '$self'}
+      end: ([:]?)|(\s)
+    end: \s
+  meta:
+    match: ^\s*([a-z][A-Za-z0-9\-]+)[:]\s
+    name: keyword.operator.directive.beancount
+  string:
+    name: string.quoted.double.beancount
+    begin: \"
+    patterns:
+    - name: constant.character.escape.beancount
+      match: \\.
+    end: \"
+  commodity:
+    name: string.unquoted.commodity.beancount
+    match: ([A-Z][A-Z0-9\-_]+)\s
+  amount:
+    match: ([\-|\+]?)([\d]+[\.]?[\d]*)\s?([A-Z][A-Z0-9\-]{0,10})
+    captures:
+      '1': {name: keyword.operator.modifier.beancount}
+      '2': {name: constant.numeric.currency.beancount}
+      '3': {name: variable.other.currency.beancount}

--- a/beancount.YAML-tmLanguage
+++ b/beancount.YAML-tmLanguage
@@ -3,131 +3,131 @@ name: Beancount
 scopeName: source.beancount
 fileTypes: [beancount]
 uuid: dbf28879-ee4d-497e-a678-a5c5a5e8d74f
-
 patterns:
 - comment: Comments
   name: comment.line.beancount
-  match:  ;.*
-
+  match: ;.*
 - comment: Tag directive
   name: meta.directive.tag.beancount
   match: ^(poptag|pushtag)\s+(#)([A-Za-z0-9\-_/.]+)\s*\n
   captures:
-    '1': {name: keyword.operator.directive.beancount}
+    '1': {name: support.function.beancount}
     '2': {name: keyword.operator.tag.beancount}
-    '3': {name: string.unquoted.tag.beancount}
-
+    '3': {name: entity.name.tag.beancount}
 - comment: Include directive
   name: meta.directive.include.beancount
   match: ^(include)\s+(\".*\")\s*\n
   captures:
-    '1': {name: keyword.operator.directive.beancount}
+    '1': {name: support.function.beancount}
     '2': {name: string.quoted.double.beancount}
-
 - comment: Option directive
   name: meta.directive.option.beancount
   match: ^(option)\s+(\".*\")\s+(\".*\")\s*\n
   captures:
-    '1': {name: support.function.directive.option.beancount}
-    '2': {name: support.variable.language.option.beancount}
+    '1': {name: support.function.beancount}
+    '2': {name: support.variable.beancount}
     '3': {name: string.quoted.double.beancount}
-
 - comment: Plugin directive
   name: keyword.operator.directive.beancount
   match: ^(plugin)\s+(\"(.*)\")\s+(\".*\")\s*\n
   captures:
-    '1': {name: keyword.operator.directive.beancount}
+    '1': {name: support.function.beancount}
     '2': {name: string.quoted.double.beancount}
     '3': {name: entity.name.function.beancount}
     '4': {name: string.quoted.double.beancount}
-
-# FIXME: Restrict use of account too many times
 - comment: Open/Close/Pad directive
   name: meta.directive.dated.beancount
-  begin: ([0-9]{4})[\-|/]([0-9]{2})[\-|/]([0-9]{2})\s(open|close|pad)
+  begin: ([0-9]{4})([\-|/])([0-9]{2})([\-|/])([0-9]{2})\s(open|close|pad)
   beginCaptures:
     '1': {name: constant.numeric.date.year.beancount}
-    '2': {name: constant.numeric.date.month.beancount}
-    '3': {name: constant.numeric.date.day.beancount}
-    '4': {name: support.function.directive.beancount}
-  patterns:
-  - include: '#account'
-  - include: '#meta'
+    '2': {name: punctuation.separator.beancount}
+    '3': {name: constant.numeric.date.month.beancount}
+    '4': {name: punctuation.separator.beancount}
+    '5': {name: constant.numeric.date.day.beancount}
+    '6': {name: support.function.beancount}
   end: (?=(^\s*$|^\S))
-
-# FIXME: Restrict use of string too many times
+  patterns:
+  - include: '#meta'
+  - include: '#account'
+  - include: '#illegal'
 - comment: Event directive
   name: meta.directive.dated.beancount
-  begin: ([0-9]{4})[\-|/]([0-9]{2})[\-|/]([0-9]{2})\s(event)
+  begin: ([0-9]{4})([\-|/])([0-9]{2})([\-|/])([0-9]{2})\s(event)
   beginCaptures:
     '1': {name: constant.numeric.date.year.beancount}
-    '2': {name: constant.numeric.date.month.beancount}
-    '3': {name: constant.numeric.date.day.beancount}
-    '4': {name: support.function.directive.beancount}
-  patterns:
-  - include: '#string'
-  - include: '#meta'
+    '2': {name: punctuation.separator.beancount}
+    '3': {name: constant.numeric.date.month.beancount}
+    '4': {name: punctuation.separator.beancount}
+    '5': {name: constant.numeric.date.day.beancount}
+    '6': {name: support.function.directive.beancount}
   end: (?=(^\s*$|^\S))
-
-# FIXME: Restrict use of commodity too many times
+  patterns:
+  - include: '#meta'
+  - include: '#string'
+  - include: '#illegal'
 - comment: Commodity directive
   name: meta.directive.dated.beancount
-  begin: ([0-9]{4})[\-|/]([0-9]{2})[\-|/]([0-9]{2})\s(commodity)
+  begin: ([0-9]{4})([\-|/])([0-9]{2})([\-|/])([0-9]{2})\s(commodity)
   beginCaptures:
     '1': {name: constant.numeric.date.year.beancount}
-    '2': {name: constant.numeric.date.month.beancount}
-    '3': {name: constant.numeric.date.day.beancount}
-    '4': {name: support.function.directive.beancount}
-  patterns:
-  - include: '#commodity'
-  - include: '#meta'
+    '2': {name: punctuation.separator.beancount}
+    '3': {name: constant.numeric.date.month.beancount}
+    '4': {name: punctuation.separator.beancount}
+    '5': {name: constant.numeric.date.day.beancount}
+    '6': {name: support.function.directive.beancount}
   end: (?=(^\s*$|^\S))
-
-# FIXME: Restrict use of account and string too many times
+  patterns:
+  - include: '#meta'
+  - include: '#commodity'
+  - include: '#illegal'
 - comment: Note/Document directive
   name: meta.directive.dated.beancount
-  begin: ([0-9]{4})[\-|/]([0-9]{2})[\-|/]([0-9]{2})\s(note|document)
+  begin: ([0-9]{4})([\-|/])([0-9]{2})([\-|/])([0-9]{2})\s(note|document)
   beginCaptures:
     '1': {name: constant.numeric.date.year.beancount}
-    '2': {name: constant.numeric.date.month.beancount}
-    '3': {name: constant.numeric.date.day.beancount}
-    '4': {name: support.function.directive.beancount}
+    '2': {name: punctuation.separator.beancount}
+    '3': {name: constant.numeric.date.month.beancount}
+    '4': {name: punctuation.separator.beancount}
+    '5': {name: constant.numeric.date.day.beancount}
+    '6': {name: support.function.directive.beancount}
+  end: (?=(^\s*$|^\S))
   patterns:
+  - include: '#meta'
   - include: '#account'
   - include: '#string'
-  - include: '#meta'
-  end: (?=(^\s*$|^\S))
-
-# FIXME: Restrict use of commodity and amount too many times
+  - include: '#illegal'
 - comment: Price directives
   name: meta.directive.dated.beancount
-  begin: ([0-9]{4})[\-|/]([0-9]{2})[\-|/]([0-9]{2})\s(price)
+  begin: ([0-9]{4})([\-|/])([0-9]{2})([\-|/])([0-9]{2})\s(price)
   beginCaptures:
     '1': {name: constant.numeric.date.year.beancount}
-    '2': {name: constant.numeric.date.month.beancount}
-    '3': {name: constant.numeric.date.day.beancount}
-    '4': {name: support.function.directive.beancount}
+    '2': {name: punctuation.separator.beancount}
+    '3': {name: constant.numeric.date.month.beancount}
+    '4': {name: punctuation.separator.beancount}
+    '5': {name: constant.numeric.date.day.beancount}
+    '6': {name: support.function.directive.beancount}
+  end: (?=(^\s*$|^\S))
   patterns:
+  - include: '#meta'
   - include: '#commodity'
   - include: '#amount'
-  - include: '#meta'
-  end: (?=(^\s*$|^\S))
-
-# FIXME: Restrict use of account and amount too many times
+  - include: '#illegal'
 - comment: Balance directives
   name: meta.directive.dated.beancount
-  begin: ([0-9]{4})[\-|/]([0-9]{2})[\-|/]([0-9]{2})\s(balance)
+  begin: ([0-9]{4})([\-|/])([0-9]{2})([\-|/])([0-9]{2})\s(balance)
   beginCaptures:
     '1': {name: constant.numeric.date.year.beancount}
-    '2': {name: constant.numeric.date.month.beancount}
-    '3': {name: constant.numeric.date.day.beancount}
-    '4': {name: support.function.directive.beancount}
+    '2': {name: punctuation.separator.beancount}
+    '3': {name: constant.numeric.date.month.beancount}
+    '4': {name: punctuation.separator.beancount}
+    '5': {name: constant.numeric.date.day.beancount}
+    '6': {name: support.function.directive.beancount}
+  end: (?=(^\s*$|^\S))
   patterns:
+  - include: '#meta'
   - include: '#account'
   - include: '#amount'
-  - include: '#meta'
-  end: (?=(^\s*$|^\S))
-
+  - include: '#illegal'
 - comment: Transaction directive
   name: meta.directive.transaction.beancount
   begin: ([0-9]{4})([\-|/])([0-9]{2})([\-|/])([0-9]{2})\s+(txn|\*|\!)(?:\s+(".*")(?=\s+"))?\s+(".*?")(?=((?:\s+#[a-zA-z\-]+(?=\s))*(?:\s+\^[a-zA-z\-\.]+(?=\s))*(?:\s+;\s*.*)?)\s)
@@ -140,75 +140,60 @@ patterns:
     '6': {name: support.function.directive.beancount}
     '7': {name: string.quoted.tiers.beancount}
     '8': {name: string.quoted.narration.beancount}
+  end: (?=(^\s*$|^\S))
   patterns:
+  - include: '#meta'
   - include: '#tag'
   - include: '#link'
-  - include: '#comment'
-  - include: '#meta'
+  - include: '#comments'
   - include: '#posting'
-  end: (?=(^\s*$|^\S))
-
-# - include: '#illegal'
-
+  - include: '#illegal'
 repository:
-  posting:
-    name: meta.posting.beancount
-    begin: ^\s+(?=([A-Z\!]))
-    patterns:
-    - include: '#flag'
-    - include: '#account'
-    - include: '#amount'
-    - include: '#cost'
-    - include: '#date'
-    - include: '#price'
-    - include: '#comment'
-    - include: '#illegal'
-    end: (?=\n)
-  flag:
-    name: keyword.other.beancount
-    match: (?<=\s)(\!)
   account:
     name: meta.account.beancount
     begin: ([A-Z][A-Za-z0-9\-]+)(:)
     beginCaptures:
       '1': {name: constant.language.beancount}
       '2': {name: punctuation.separator.beancount}
+    end: \s
     patterns:
     - comment: Sub accounts
       begin: ([A-Z][A-Za-z0-9\-]+)([:]?)
       beginCaptures:
         '1': {name: variable.account.beancount}
         '2': {name: punctuation.separator.beancount}
-      patterns:
-      - {include: '$self'}
       end: ([:]?)|(\s)
-    end: \s
+      patterns:
+      - include: $self
+      - include: '#illegal'
   amount:
     name: meta.amount.beancount
     match: ([\-|\+]?)([\d]+[\.]?[\d]*)\s*([A-Z][A-Z0-9\'\.\_\-]{0,22}[A-Z0-9])
     captures:
       '1': {name: keyword.operator.modifier.beancount}
       '2': {name: constant.numeric.currency.beancount}
-      '3': {name: variable.other.currency.beancount}
+      '3': {name: entity.type.commodity.beancount}
+  comments:
+    match: (?<=\s)(;.*)(?=\n)
+    captures:
+      '1': {name: comment.line.beancount}
+  commodity:
+    name: entity.type.commodity.beancount
+    match: ([A-Z][A-Z0-9\'\.\_\-]{0,22}[A-Z0-9])
   cost:
     name: meta.cost.beancount
     begin: \{
     beginCaptures:
       '0': {name: keyword.operator.assignment.beancount}
-    patterns:
-    - include: '#date'
-    - include: '#amount'
     end: \}
     endCaptures:
       '0': {name: keyword.operator.assignment.beancount}
-  price:
-    name: meta.price.beancount
-    begin: \@
-    beginCaptures:
-      '0': {name: keyword.operator.assignment.beancount}
     patterns:
     - include: '#amount'
-    end: (?=(;|\n))
+    - include: '#date'
+    - name: punctuation.separator.beancount
+      match: \,
+    - include: '#illegal'
   date:
     name: meta.date.beancount
     match: ([0-9]{4})([\-|/])([0-9]{2})([\-|/])([0-9]{2})
@@ -218,40 +203,59 @@ repository:
       '3': {name: constant.numeric.date.month.beancount}
       '4': {name: punctuation.separator.beancount}
       '5': {name: constant.numeric.date.day.beancount}
+  flag:
+    name: keyword.other.beancount
+    match: (?<=\s)(\!)
+  illegal:
+    name: invalid.illegal.unrecognized.beancount
+    match: '[^\s]'
+  link:
+    match: (?<=\s)(\^)([A-Za-z0-9\-_/.]+)(?=\s)
+    captures:
+      '1': {name: keyword.operator.link.beancount}
+      '2': {name: markup.underline.link.beancount}
   meta:
     name: meta.meta.beancount
     begin: ^\s*([a-z][A-Za-z0-9\-]+)([:])\s
     beginCaptures:
       '1': {name: keyword.operator.directive.beancount}
       '2': {name: punctuation.separator.beancount}
+    end: \n
     patterns:
     - include: '#string'
-    - include: '#comment'
-    end: \n
+    - include: '#comments'
+    - include: '#illegal'
+  posting:
+    name: meta.posting.beancount
+    begin: ^\s+(?=([A-Z\!]))
+    end: (?=\n)
+    patterns:
+    - include: '#flag'
+    - include: '#account'
+    - include: '#amount'
+    - include: '#cost'
+    - include: '#date'
+    - include: '#price'
+    - include: '#comments'
+    - include: '#illegal'
+  price:
+    name: meta.price.beancount
+    begin: \@
+    beginCaptures:
+      '0': {name: keyword.operator.assignment.beancount}
+    end: (?=(;|\n))
+    patterns:
+    - include: '#amount'
+    - include: '#illegal'
   string:
     name: string.quoted.double.beancount
     begin: \"
+    end: \"
     patterns:
     - name: constant.character.escape.beancount
       match: \\.
-    end: \"
-  commodity:
-    name: string.unquoted.commodity.beancount
-    match: ([A-Z][A-Z0-9\'\.\_\-]{0,22}[A-Z0-9])
   tag:
     match: (?<=\s)(#)([A-Za-z0-9\-_/.]+)(?=\s)
     captures:
       '1': {name: keyword.operator.tag.beancount}
       '2': {name: entity.name.tag.beancount}
-  link:
-    match: (?<=\s)(\^)([A-Za-z0-9\-_/.]+)(?=\s)
-    captures:
-      '1': {name: keyword.operator.link.beancount}
-      '2': {name: markup.underline.link.beancount}
-  comment:
-    match: (?<=\s)(;.*)(?=\n)
-    captures:
-      '1': {name: comment.line.beancount}
-  illegal:
-    name: invalid.illegal.unrecognized.beancount
-    match: '[^\s]'

--- a/beancount.YAML-tmLanguage
+++ b/beancount.YAML-tmLanguage
@@ -8,26 +8,35 @@ uuid: dbf28879-ee4d-497e-a678-a5c5a5e8d74f
 patterns:
 - comment: Commented text
   name: comment.line.beancount
-  match:  \s;\s+.*
+  match:  ;.*
 
-- comment: Root Accounts
-  match: \s([A-Z][A-Za-z0-9\-]+)(:)
-  captures:
+- comment: Account
+  begin: ([A-Z][A-Za-z0-9\-]+)(:)
+  beginCaptures:
     '1': {name: constant.language.beancount}
     '2': {name: punctuation.separator.beancount}
-
-- comment: Accounts
-  begin: ([:]?)([A-Z][A-Za-z0-9\-]+)
-  beginCaptures:
-    '1': {name: punctuation.separator.beancount}
-    '2': {name: constant.language.beancount}
   patterns:
-  - {include: '$self'}
-  end: ([:]?)|(\s)
+  - comment: Sub accounts
+    begin: ([A-Z][A-Za-z0-9\-]+)([:]?)
+    beginCaptures:
+      '1': {name: variable.account.beancount}
+      '2': {name: punctuation.separator.beancount}
+    patterns:
+    - {include: '$self'}
+    end: ([:]?)|(\s)
+  end: \s
 
 - comment: strings
   name: string.quoted.double.beancount
-  match: \".*\"
+  begin: \"
+  patterns:
+  - name: constant.character.escape.beancount
+    match: \\.
+  end: \"
+
+# - comment: strings
+#   name: string.quoted.double.beancount
+#   match: \".*\"
 
 - comment: Option directives
   name: meta.directive.option.beancount
@@ -39,7 +48,7 @@ patterns:
 
 - comment: Directives (no date)
   name: keyword.operator.directive.beancount
-  match: ^(poptag|pushtag|include)\s
+  match: ^(poptag|pushtag|include|plugin)\s
 
 - comment: Dated directives
   match: ([0-9]{4})[\-|/]([0-9]{2})[\-|/]([0-9]{2})\s(open|close|pad|balance|note|price|event|document|commodity)
@@ -49,8 +58,8 @@ patterns:
     '3': {name: constant.numeric.date.day.beancount}
     '4': {name: support.function.directive.beancount}
 # FIXME: this violates DRY
-- comment: second line
-  match: \s\s(name|isin|old-name|asset-class)[:]
+- comment: metadata
+  match: \s\s([a-z][A-Za-z0-9\-]+)[:]\s
   name: keyword.operator.directive.beancount
 
 - comment: Transactions
@@ -66,7 +75,7 @@ patterns:
 
 - comment: flag
   name: keyword.other.beancount
-  match: \!\s
+  match: \s\!
 
 - comment: Price assignment
   name: keyword.operator.assignment.beancount
@@ -87,6 +96,7 @@ patterns:
 - comment: Tags and links
   match: (#)([A-Za-z0-9\-_/.]+)
   captures:
+    '1': {name: keyword.operator.tag.beancount}
     '2': {name: string.unquoted.tag.beancount}
 
 - comment: Links

--- a/beancount.tmLanguage
+++ b/beancount.tmLanguage
@@ -12,11 +12,58 @@
 	<array>
 		<dict>
 			<key>comment</key>
-			<string>Commented text</string>
+			<string>Comments</string>
 			<key>match</key>
 			<string>;.*</string>
 			<key>name</key>
 			<string>comment.line.beancount</string>
+		</dict>
+		<dict>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>keyword.operator.directive.beancount</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>keyword.operator.tag.beancount</string>
+				</dict>
+				<key>3</key>
+				<dict>
+					<key>name</key>
+					<string>string.unquoted.tag.beancount</string>
+				</dict>
+			</dict>
+			<key>comment</key>
+			<string>Tag directive (no date, no string, tag, no meta, no ops)</string>
+			<key>match</key>
+			<string>^(poptag|pushtag)\s+(#)([A-Za-z0-9\-_/.]+)\s*\n</string>
+			<key>name</key>
+			<string>meta.directive.tag.beancount</string>
+		</dict>
+		<dict>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>keyword.operator.directive.beancount</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>string.quoted.double.beancount</string>
+				</dict>
+			</dict>
+			<key>comment</key>
+			<string>Include directive (no date, string x1, no tag, no meta, no ops)</string>
+			<key>match</key>
+			<string>^(include)\s+(\".*\")\s*\n</string>
+			<key>name</key>
+			<string>meta.directive.include.beancount</string>
 		</dict>
 		<dict>
 			<key>begin</key>
@@ -105,26 +152,51 @@
 				<key>3</key>
 				<dict>
 					<key>name</key>
-					<string>support.class.option.beancount</string>
+					<string>string.quoted.double.beancount</string>
 				</dict>
 			</dict>
 			<key>comment</key>
-			<string>Option directives</string>
+			<string>Option directive (no date, string x2, no tag, no meta, no ops)</string>
 			<key>match</key>
-			<string>^(option)\s*(\".*\")\s*(\".*\")\s*</string>
+			<string>^(option)\s+(\".*\")\s+(\".*\")\s*\n</string>
 			<key>name</key>
 			<string>meta.directive.option.beancount</string>
 		</dict>
 		<dict>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>keyword.operator.directive.beancount</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>string.quoted.double.beancount</string>
+				</dict>
+				<key>3</key>
+				<dict>
+					<key>name</key>
+					<string>entity.name.function.beancount</string>
+				</dict>
+				<key>4</key>
+				<dict>
+					<key>name</key>
+					<string>string.quoted.double.beancount</string>
+				</dict>
+			</dict>
 			<key>comment</key>
-			<string>Directives (no date)</string>
+			<string>Plugin directive (no date, string x2, no tag, no meta, no ops)</string>
 			<key>match</key>
-			<string>^(poptag|pushtag|include|plugin)\s</string>
+			<string>^(plugin)\s+(\"(.*)\")\s+(\".*\")\s*\n</string>
 			<key>name</key>
 			<string>keyword.operator.directive.beancount</string>
 		</dict>
 		<dict>
-			<key>captures</key>
+			<key>begin</key>
+			<string>([0-9]{4})[\-|/]([0-9]{2})[\-|/]([0-9]{2})\s(open|close|pad)</string>
+			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>
 				<dict>
@@ -148,17 +220,254 @@
 				</dict>
 			</dict>
 			<key>comment</key>
-			<string>Dated directives</string>
-			<key>match</key>
-			<string>([0-9]{4})[\-|/]([0-9]{2})[\-|/]([0-9]{2})\s(open|close|pad|balance|note|price|event|document|commodity)</string>
+			<string>Open/Close/Pad directive (date, account, no tag, meta?)</string>
+			<key>end</key>
+			<string>^(?!\s)</string>
+			<key>name</key>
+			<string>meta.directive.dated.beancount</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>#account</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#meta</string>
+				</dict>
+			</array>
 		</dict>
 		<dict>
+			<key>begin</key>
+			<string>([0-9]{4})[\-|/]([0-9]{2})[\-|/]([0-9]{2})\s(event)</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>constant.numeric.date.year.beancount</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>constant.numeric.date.month.beancount</string>
+				</dict>
+				<key>3</key>
+				<dict>
+					<key>name</key>
+					<string>constant.numeric.date.day.beancount</string>
+				</dict>
+				<key>4</key>
+				<dict>
+					<key>name</key>
+					<string>support.function.directive.beancount</string>
+				</dict>
+			</dict>
 			<key>comment</key>
-			<string>metadata</string>
-			<key>match</key>
-			<string>\s\s([a-z][A-Za-z0-9\-]+)[:]\s</string>
+			<string>Event directive (date, string, no tag, meta?)</string>
+			<key>end</key>
+			<string>^(?!\s)</string>
 			<key>name</key>
-			<string>keyword.operator.directive.beancount</string>
+			<string>meta.directive.dated.beancount</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>#string</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#meta</string>
+				</dict>
+			</array>
+		</dict>
+		<dict>
+			<key>begin</key>
+			<string>([0-9]{4})[\-|/]([0-9]{2})[\-|/]([0-9]{2})\s(commodity)</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>constant.numeric.date.year.beancount</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>constant.numeric.date.month.beancount</string>
+				</dict>
+				<key>3</key>
+				<dict>
+					<key>name</key>
+					<string>constant.numeric.date.day.beancount</string>
+				</dict>
+				<key>4</key>
+				<dict>
+					<key>name</key>
+					<string>support.function.directive.beancount</string>
+				</dict>
+			</dict>
+			<key>comment</key>
+			<string>Commodity directive (date, account, string, no tag, meta?)</string>
+			<key>end</key>
+			<string>^(?!\s)</string>
+			<key>name</key>
+			<string>meta.directive.dated.beancount</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>#commodity</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#meta</string>
+				</dict>
+			</array>
+		</dict>
+		<dict>
+			<key>begin</key>
+			<string>([0-9]{4})[\-|/]([0-9]{2})[\-|/]([0-9]{2})\s(note|document)</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>constant.numeric.date.year.beancount</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>constant.numeric.date.month.beancount</string>
+				</dict>
+				<key>3</key>
+				<dict>
+					<key>name</key>
+					<string>constant.numeric.date.day.beancount</string>
+				</dict>
+				<key>4</key>
+				<dict>
+					<key>name</key>
+					<string>support.function.directive.beancount</string>
+				</dict>
+			</dict>
+			<key>comment</key>
+			<string>Note/Document directive (date, account, string, no tag, meta?)</string>
+			<key>end</key>
+			<string>^(?!\s)</string>
+			<key>name</key>
+			<string>meta.directive.dated.beancount</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>#account</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#string</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#meta</string>
+				</dict>
+			</array>
+		</dict>
+		<dict>
+			<key>begin</key>
+			<string>([0-9]{4})[\-|/]([0-9]{2})[\-|/]([0-9]{2})\s(price)</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>constant.numeric.date.year.beancount</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>constant.numeric.date.month.beancount</string>
+				</dict>
+				<key>3</key>
+				<dict>
+					<key>name</key>
+					<string>constant.numeric.date.day.beancount</string>
+				</dict>
+				<key>4</key>
+				<dict>
+					<key>name</key>
+					<string>support.function.directive.beancount</string>
+				</dict>
+			</dict>
+			<key>comment</key>
+			<string>Price directives (date, string?, no tag, meta?)</string>
+			<key>end</key>
+			<string>^(?!\s)</string>
+			<key>name</key>
+			<string>meta.directive.dated.beancount</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>#commodity</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#amount</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#meta</string>
+				</dict>
+			</array>
+		</dict>
+		<dict>
+			<key>begin</key>
+			<string>([0-9]{4})[\-|/]([0-9]{2})[\-|/]([0-9]{2})\s(balance)</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>constant.numeric.date.year.beancount</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>constant.numeric.date.month.beancount</string>
+				</dict>
+				<key>3</key>
+				<dict>
+					<key>name</key>
+					<string>constant.numeric.date.day.beancount</string>
+				</dict>
+				<key>4</key>
+				<dict>
+					<key>name</key>
+					<string>support.function.directive.beancount</string>
+				</dict>
+			</dict>
+			<key>comment</key>
+			<string>Balance directives (date, string?, no tag, meta?)</string>
+			<key>end</key>
+			<string>^(?!\s)</string>
+			<key>name</key>
+			<string>meta.directive.dated.beancount</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>#account</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#amount</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#meta</string>
+				</dict>
+			</array>
 		</dict>
 		<dict>
 			<key>captures</key>
@@ -314,6 +623,115 @@
 			<string>invalid.illegal.unrecognized.beancount</string>
 		</dict>
 	</array>
+	<key>repository</key>
+	<dict>
+		<key>account</key>
+		<dict>
+			<key>begin</key>
+			<string>([A-Z][A-Za-z0-9\-]+)(:)</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>constant.language.beancount</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.separator.beancount</string>
+				</dict>
+			</dict>
+			<key>end</key>
+			<string>\s</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>begin</key>
+					<string>([A-Z][A-Za-z0-9\-]+)([:]?)</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>variable.account.beancount</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.separator.beancount</string>
+						</dict>
+					</dict>
+					<key>comment</key>
+					<string>Sub accounts</string>
+					<key>end</key>
+					<string>([:]?)|(\s)</string>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>include</key>
+							<string>$self</string>
+						</dict>
+					</array>
+				</dict>
+			</array>
+		</dict>
+		<key>amount</key>
+		<dict>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>keyword.operator.modifier.beancount</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>constant.numeric.currency.beancount</string>
+				</dict>
+				<key>3</key>
+				<dict>
+					<key>name</key>
+					<string>variable.other.currency.beancount</string>
+				</dict>
+			</dict>
+			<key>match</key>
+			<string>([\-|\+]?)([\d]+[\.]?[\d]*)\s?([A-Z][A-Z0-9\-]{0,10})</string>
+		</dict>
+		<key>commodity</key>
+		<dict>
+			<key>match</key>
+			<string>([A-Z][A-Z0-9\-_]+)\s</string>
+			<key>name</key>
+			<string>string.unquoted.commodity.beancount</string>
+		</dict>
+		<key>meta</key>
+		<dict>
+			<key>match</key>
+			<string>^\s*([a-z][A-Za-z0-9\-]+)[:]\s</string>
+			<key>name</key>
+			<string>keyword.operator.directive.beancount</string>
+		</dict>
+		<key>string</key>
+		<dict>
+			<key>begin</key>
+			<string>\"</string>
+			<key>end</key>
+			<string>\"</string>
+			<key>name</key>
+			<string>string.quoted.double.beancount</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>match</key>
+					<string>\\.</string>
+					<key>name</key>
+					<string>constant.character.escape.beancount</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
 	<key>scopeName</key>
 	<string>source.beancount</string>
 	<key>uuid</key>

--- a/beancount.tmLanguage
+++ b/beancount.tmLanguage
@@ -38,7 +38,7 @@
 				</dict>
 			</dict>
 			<key>comment</key>
-			<string>Tag directive (no date, no string, tag, no meta, no ops)</string>
+			<string>Tag directive</string>
 			<key>match</key>
 			<string>^(poptag|pushtag)\s+(#)([A-Za-z0-9\-_/.]+)\s*\n</string>
 			<key>name</key>
@@ -59,82 +59,11 @@
 				</dict>
 			</dict>
 			<key>comment</key>
-			<string>Include directive (no date, string x1, no tag, no meta, no ops)</string>
+			<string>Include directive</string>
 			<key>match</key>
 			<string>^(include)\s+(\".*\")\s*\n</string>
 			<key>name</key>
 			<string>meta.directive.include.beancount</string>
-		</dict>
-		<dict>
-			<key>begin</key>
-			<string>([A-Z][A-Za-z0-9\-]+)(:)</string>
-			<key>beginCaptures</key>
-			<dict>
-				<key>1</key>
-				<dict>
-					<key>name</key>
-					<string>constant.language.beancount</string>
-				</dict>
-				<key>2</key>
-				<dict>
-					<key>name</key>
-					<string>punctuation.separator.beancount</string>
-				</dict>
-			</dict>
-			<key>comment</key>
-			<string>Account</string>
-			<key>end</key>
-			<string>\s</string>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>begin</key>
-					<string>([A-Z][A-Za-z0-9\-]+)([:]?)</string>
-					<key>beginCaptures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>variable.account.beancount</string>
-						</dict>
-						<key>2</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.separator.beancount</string>
-						</dict>
-					</dict>
-					<key>comment</key>
-					<string>Sub accounts</string>
-					<key>end</key>
-					<string>([:]?)|(\s)</string>
-					<key>patterns</key>
-					<array>
-						<dict>
-							<key>include</key>
-							<string>$self</string>
-						</dict>
-					</array>
-				</dict>
-			</array>
-		</dict>
-		<dict>
-			<key>begin</key>
-			<string>\"</string>
-			<key>comment</key>
-			<string>strings</string>
-			<key>end</key>
-			<string>\"</string>
-			<key>name</key>
-			<string>string.quoted.double.beancount</string>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>match</key>
-					<string>\\.</string>
-					<key>name</key>
-					<string>constant.character.escape.beancount</string>
-				</dict>
-			</array>
 		</dict>
 		<dict>
 			<key>captures</key>
@@ -156,7 +85,7 @@
 				</dict>
 			</dict>
 			<key>comment</key>
-			<string>Option directive (no date, string x2, no tag, no meta, no ops)</string>
+			<string>Option directive</string>
 			<key>match</key>
 			<string>^(option)\s+(\".*\")\s+(\".*\")\s*\n</string>
 			<key>name</key>
@@ -187,7 +116,7 @@
 				</dict>
 			</dict>
 			<key>comment</key>
-			<string>Plugin directive (no date, string x2, no tag, no meta, no ops)</string>
+			<string>Plugin directive</string>
 			<key>match</key>
 			<string>^(plugin)\s+(\"(.*)\")\s+(\".*\")\s*\n</string>
 			<key>name</key>
@@ -220,9 +149,9 @@
 				</dict>
 			</dict>
 			<key>comment</key>
-			<string>Open/Close/Pad directive (date, account, no tag, meta?)</string>
+			<string>Open/Close/Pad directive</string>
 			<key>end</key>
-			<string>^(?!\s)</string>
+			<string>(?=(^\s*$|^\S))</string>
 			<key>name</key>
 			<string>meta.directive.dated.beancount</string>
 			<key>patterns</key>
@@ -264,9 +193,9 @@
 				</dict>
 			</dict>
 			<key>comment</key>
-			<string>Event directive (date, string, no tag, meta?)</string>
+			<string>Event directive</string>
 			<key>end</key>
-			<string>^(?!\s)</string>
+			<string>(?=(^\s*$|^\S))</string>
 			<key>name</key>
 			<string>meta.directive.dated.beancount</string>
 			<key>patterns</key>
@@ -308,9 +237,9 @@
 				</dict>
 			</dict>
 			<key>comment</key>
-			<string>Commodity directive (date, account, string, no tag, meta?)</string>
+			<string>Commodity directive</string>
 			<key>end</key>
-			<string>^(?!\s)</string>
+			<string>(?=(^\s*$|^\S))</string>
 			<key>name</key>
 			<string>meta.directive.dated.beancount</string>
 			<key>patterns</key>
@@ -352,9 +281,9 @@
 				</dict>
 			</dict>
 			<key>comment</key>
-			<string>Note/Document directive (date, account, string, no tag, meta?)</string>
+			<string>Note/Document directive</string>
 			<key>end</key>
-			<string>^(?!\s)</string>
+			<string>(?=(^\s*$|^\S))</string>
 			<key>name</key>
 			<string>meta.directive.dated.beancount</string>
 			<key>patterns</key>
@@ -400,9 +329,9 @@
 				</dict>
 			</dict>
 			<key>comment</key>
-			<string>Price directives (date, string?, no tag, meta?)</string>
+			<string>Price directives</string>
 			<key>end</key>
-			<string>^(?!\s)</string>
+			<string>(?=(^\s*$|^\S))</string>
 			<key>name</key>
 			<string>meta.directive.dated.beancount</string>
 			<key>patterns</key>
@@ -448,9 +377,9 @@
 				</dict>
 			</dict>
 			<key>comment</key>
-			<string>Balance directives (date, string?, no tag, meta?)</string>
+			<string>Balance directives</string>
 			<key>end</key>
-			<string>^(?!\s)</string>
+			<string>(?=(^\s*$|^\S))</string>
 			<key>name</key>
 			<string>meta.directive.dated.beancount</string>
 			<key>patterns</key>
@@ -470,157 +399,80 @@
 			</array>
 		</dict>
 		<dict>
-			<key>captures</key>
-			<dict>
-				<key>1</key>
-				<dict>
-					<key>name</key>
-					<string>constant.numeric.date.beancount</string>
-				</dict>
-				<key>2</key>
-				<dict>
-					<key>name</key>
-					<string>support.function.directive.beancount</string>
-				</dict>
-				<key>4</key>
-				<dict>
-					<key>name</key>
-					<string>string.quoted.tiers.beancount</string>
-				</dict>
-				<key>5</key>
-				<dict>
-					<key>name</key>
-					<string>string.quoted.narration.beancount</string>
-				</dict>
-				<key>6</key>
-				<dict>
-					<key>name</key>
-					<string>keyword.operator.tags.beancount</string>
-				</dict>
-				<key>8</key>
-				<dict>
-					<key>name</key>
-					<string>comment.line.beancount</string>
-				</dict>
-			</dict>
-			<key>comment</key>
-			<string>Transactions</string>
-			<key>match</key>
-			<string>([0-9]{4}[\-|/][0-9]{2}[\-|/][0-9]{2})\s((txn)|\*|\!)\s(".*?")(\s+".*?")?((\s*#[a-zA-z\-]+)*)(\s*;.*)?</string>
-		</dict>
-		<dict>
-			<key>comment</key>
-			<string>flag</string>
-			<key>match</key>
-			<string>\s\!</string>
-			<key>name</key>
-			<string>keyword.other.beancount</string>
-		</dict>
-		<dict>
-			<key>comment</key>
-			<string>Price assignment</string>
-			<key>match</key>
-			<string>\@</string>
-			<key>name</key>
-			<string>keyword.operator.assignment.beancount</string>
-		</dict>
-		<dict>
 			<key>begin</key>
-			<string>(\{)</string>
+			<string>([0-9]{4})([\-|/])([0-9]{2})([\-|/])([0-9]{2})\s+(txn|\*|\!)(?:\s+(".*")(?=\s+"))?\s+(".*?")(?=((?:\s+#[a-zA-z\-]+(?=\s))*(?:\s+\^[a-zA-z\-\.]+(?=\s))*(?:\s+;\s*.*)?)\s)</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>
 				<dict>
 					<key>name</key>
-					<string>keyword.operator.assignment.beancount</string>
-				</dict>
-			</dict>
-			<key>comment</key>
-			<string>cost assignment</string>
-			<key>end</key>
-			<string>(\})</string>
-			<key>endCaptures</key>
-			<dict>
-				<key>1</key>
-				<dict>
-					<key>name</key>
-					<string>keyword.operator.assignment.beancount</string>
-				</dict>
-			</dict>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>match</key>
-					<string>\/</string>
-					<key>name</key>
-					<string>keyword.operator.assignment.beancount</string>
-				</dict>
-			</array>
-		</dict>
-		<dict>
-			<key>captures</key>
-			<dict>
-				<key>1</key>
-				<dict>
-					<key>name</key>
-					<string>keyword.operator.tag.beancount</string>
+					<string>constant.numeric.date.year.beancount</string>
 				</dict>
 				<key>2</key>
 				<dict>
 					<key>name</key>
-					<string>string.unquoted.tag.beancount</string>
-				</dict>
-			</dict>
-			<key>comment</key>
-			<string>Tags and links</string>
-			<key>match</key>
-			<string>(#)([A-Za-z0-9\-_/.]+)</string>
-		</dict>
-		<dict>
-			<key>captures</key>
-			<dict>
-				<key>2</key>
-				<dict>
-					<key>name</key>
-					<string>string.unquoted.link.beancount</string>
-				</dict>
-			</dict>
-			<key>comment</key>
-			<string>Links</string>
-			<key>match</key>
-			<string>(\^)([A-Za-z0-9\-_/.]+)</string>
-		</dict>
-		<dict>
-			<key>captures</key>
-			<dict>
-				<key>1</key>
-				<dict>
-					<key>name</key>
-					<string>keyword.operator.modifier.beancount</string>
-				</dict>
-				<key>2</key>
-				<dict>
-					<key>name</key>
-					<string>constant.numeric.currency.beancount</string>
+					<string>punctuation.separator.beancount</string>
 				</dict>
 				<key>3</key>
 				<dict>
 					<key>name</key>
-					<string>variable.other.currency.beancount</string>
+					<string>constant.numeric.date.month.beancount</string>
+				</dict>
+				<key>4</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.separator.beancount</string>
+				</dict>
+				<key>5</key>
+				<dict>
+					<key>name</key>
+					<string>constant.numeric.date.day.beancount</string>
+				</dict>
+				<key>6</key>
+				<dict>
+					<key>name</key>
+					<string>support.function.directive.beancount</string>
+				</dict>
+				<key>7</key>
+				<dict>
+					<key>name</key>
+					<string>string.quoted.tiers.beancount</string>
+				</dict>
+				<key>8</key>
+				<dict>
+					<key>name</key>
+					<string>string.quoted.narration.beancount</string>
 				</dict>
 			</dict>
 			<key>comment</key>
-			<string>numbers</string>
-			<key>match</key>
-			<string>([\-|\+]?)([\d]+[\.]?[\d]*)\s?([A-Z][A-Z0-9\-]{0,10})</string>
-		</dict>
-		<dict>
-			<key>comment</key>
-			<string>Illegal</string>
-			<key>match</key>
-			<string>[^\s}]</string>
+			<string>Transaction directive</string>
+			<key>end</key>
+			<string>(?=(^\s*$|^\S))</string>
 			<key>name</key>
-			<string>invalid.illegal.unrecognized.beancount</string>
+			<string>meta.directive.transaction.beancount</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>#tag</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#link</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#comment</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#meta</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#posting</string>
+				</dict>
+			</array>
 		</dict>
 	</array>
 	<key>repository</key>
@@ -644,6 +496,8 @@
 			</dict>
 			<key>end</key>
 			<string>\s</string>
+			<key>name</key>
+			<string>meta.account.beancount</string>
 			<key>patterns</key>
 			<array>
 				<dict>
@@ -697,21 +551,233 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>([\-|\+]?)([\d]+[\.]?[\d]*)\s?([A-Z][A-Z0-9\-]{0,10})</string>
+			<string>([\-|\+]?)([\d]+[\.]?[\d]*)\s*([A-Z][A-Z0-9\'\.\_\-]{0,22}[A-Z0-9])</string>
+			<key>name</key>
+			<string>meta.amount.beancount</string>
+		</dict>
+		<key>comment</key>
+		<dict>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>comment.line.beancount</string>
+				</dict>
+			</dict>
+			<key>match</key>
+			<string>(?&lt;=\s)(;.*)(?=\n)</string>
 		</dict>
 		<key>commodity</key>
 		<dict>
 			<key>match</key>
-			<string>([A-Z][A-Z0-9\-_]+)\s</string>
+			<string>([A-Z][A-Z0-9\'\.\_\-]{0,22}[A-Z0-9])</string>
 			<key>name</key>
 			<string>string.unquoted.commodity.beancount</string>
 		</dict>
-		<key>meta</key>
+		<key>cost</key>
+		<dict>
+			<key>begin</key>
+			<string>\{</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>0</key>
+				<dict>
+					<key>name</key>
+					<string>keyword.operator.assignment.beancount</string>
+				</dict>
+			</dict>
+			<key>end</key>
+			<string>\}</string>
+			<key>endCaptures</key>
+			<dict>
+				<key>0</key>
+				<dict>
+					<key>name</key>
+					<string>keyword.operator.assignment.beancount</string>
+				</dict>
+			</dict>
+			<key>name</key>
+			<string>meta.cost.beancount</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>#date</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#amount</string>
+				</dict>
+			</array>
+		</dict>
+		<key>date</key>
+		<dict>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>constant.numeric.date.year.beancount</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.separator.beancount</string>
+				</dict>
+				<key>3</key>
+				<dict>
+					<key>name</key>
+					<string>constant.numeric.date.month.beancount</string>
+				</dict>
+				<key>4</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.separator.beancount</string>
+				</dict>
+				<key>5</key>
+				<dict>
+					<key>name</key>
+					<string>constant.numeric.date.day.beancount</string>
+				</dict>
+			</dict>
+			<key>match</key>
+			<string>([0-9]{4})([\-|/])([0-9]{2})([\-|/])([0-9]{2})</string>
+			<key>name</key>
+			<string>meta.date.beancount</string>
+		</dict>
+		<key>flag</key>
 		<dict>
 			<key>match</key>
-			<string>^\s*([a-z][A-Za-z0-9\-]+)[:]\s</string>
+			<string>(?&lt;=\s)(\!)</string>
 			<key>name</key>
-			<string>keyword.operator.directive.beancount</string>
+			<string>keyword.other.beancount</string>
+		</dict>
+		<key>illegal</key>
+		<dict>
+			<key>match</key>
+			<string>[^\s]</string>
+			<key>name</key>
+			<string>invalid.illegal.unrecognized.beancount</string>
+		</dict>
+		<key>link</key>
+		<dict>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>keyword.operator.link.beancount</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>markup.underline.link.beancount</string>
+				</dict>
+			</dict>
+			<key>match</key>
+			<string>(?&lt;=\s)(\^)([A-Za-z0-9\-_/.]+)(?=\s)</string>
+		</dict>
+		<key>meta</key>
+		<dict>
+			<key>begin</key>
+			<string>^\s*([a-z][A-Za-z0-9\-]+)([:])\s</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>keyword.operator.directive.beancount</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.separator.beancount</string>
+				</dict>
+			</dict>
+			<key>end</key>
+			<string>\n</string>
+			<key>name</key>
+			<string>meta.meta.beancount</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>#string</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#comment</string>
+				</dict>
+			</array>
+		</dict>
+		<key>posting</key>
+		<dict>
+			<key>begin</key>
+			<string>^\s+(?=([A-Z\!]))</string>
+			<key>end</key>
+			<string>(?=\n)</string>
+			<key>name</key>
+			<string>meta.posting.beancount</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>#flag</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#account</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#amount</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#cost</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#date</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#price</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#comment</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#illegal</string>
+				</dict>
+			</array>
+		</dict>
+		<key>price</key>
+		<dict>
+			<key>begin</key>
+			<string>\@</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>0</key>
+				<dict>
+					<key>name</key>
+					<string>keyword.operator.assignment.beancount</string>
+				</dict>
+			</dict>
+			<key>end</key>
+			<string>(?=(;|\n))</string>
+			<key>name</key>
+			<string>meta.price.beancount</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>#amount</string>
+				</dict>
+			</array>
 		</dict>
 		<key>string</key>
 		<dict>
@@ -730,6 +796,24 @@
 					<string>constant.character.escape.beancount</string>
 				</dict>
 			</array>
+		</dict>
+		<key>tag</key>
+		<dict>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>keyword.operator.tag.beancount</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>entity.name.tag.beancount</string>
+				</dict>
+			</dict>
+			<key>match</key>
+			<string>(?&lt;=\s)(#)([A-Za-z0-9\-_/.]+)(?=\s)</string>
 		</dict>
 	</dict>
 	<key>scopeName</key>

--- a/beancount.tmLanguage
+++ b/beancount.tmLanguage
@@ -24,7 +24,7 @@
 				<key>1</key>
 				<dict>
 					<key>name</key>
-					<string>keyword.operator.directive.beancount</string>
+					<string>support.function.beancount</string>
 				</dict>
 				<key>2</key>
 				<dict>
@@ -34,7 +34,7 @@
 				<key>3</key>
 				<dict>
 					<key>name</key>
-					<string>string.unquoted.tag.beancount</string>
+					<string>entity.name.tag.beancount</string>
 				</dict>
 			</dict>
 			<key>comment</key>
@@ -50,7 +50,7 @@
 				<key>1</key>
 				<dict>
 					<key>name</key>
-					<string>keyword.operator.directive.beancount</string>
+					<string>support.function.beancount</string>
 				</dict>
 				<key>2</key>
 				<dict>
@@ -71,12 +71,12 @@
 				<key>1</key>
 				<dict>
 					<key>name</key>
-					<string>support.function.directive.option.beancount</string>
+					<string>support.function.beancount</string>
 				</dict>
 				<key>2</key>
 				<dict>
 					<key>name</key>
-					<string>support.variable.language.option.beancount</string>
+					<string>support.variable.beancount</string>
 				</dict>
 				<key>3</key>
 				<dict>
@@ -97,7 +97,7 @@
 				<key>1</key>
 				<dict>
 					<key>name</key>
-					<string>keyword.operator.directive.beancount</string>
+					<string>support.function.beancount</string>
 				</dict>
 				<key>2</key>
 				<dict>
@@ -124,7 +124,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>([0-9]{4})[\-|/]([0-9]{2})[\-|/]([0-9]{2})\s(open|close|pad)</string>
+			<string>([0-9]{4})([\-|/])([0-9]{2})([\-|/])([0-9]{2})\s(open|close|pad)</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>
@@ -135,17 +135,27 @@
 				<key>2</key>
 				<dict>
 					<key>name</key>
-					<string>constant.numeric.date.month.beancount</string>
+					<string>punctuation.separator.beancount</string>
 				</dict>
 				<key>3</key>
 				<dict>
 					<key>name</key>
-					<string>constant.numeric.date.day.beancount</string>
+					<string>constant.numeric.date.month.beancount</string>
 				</dict>
 				<key>4</key>
 				<dict>
 					<key>name</key>
-					<string>support.function.directive.beancount</string>
+					<string>punctuation.separator.beancount</string>
+				</dict>
+				<key>5</key>
+				<dict>
+					<key>name</key>
+					<string>constant.numeric.date.day.beancount</string>
+				</dict>
+				<key>6</key>
+				<dict>
+					<key>name</key>
+					<string>support.function.beancount</string>
 				</dict>
 			</dict>
 			<key>comment</key>
@@ -158,17 +168,21 @@
 			<array>
 				<dict>
 					<key>include</key>
+					<string>#meta</string>
+				</dict>
+				<dict>
+					<key>include</key>
 					<string>#account</string>
 				</dict>
 				<dict>
 					<key>include</key>
-					<string>#meta</string>
+					<string>#illegal</string>
 				</dict>
 			</array>
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>([0-9]{4})[\-|/]([0-9]{2})[\-|/]([0-9]{2})\s(event)</string>
+			<string>([0-9]{4})([\-|/])([0-9]{2})([\-|/])([0-9]{2})\s(event)</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>
@@ -179,14 +193,24 @@
 				<key>2</key>
 				<dict>
 					<key>name</key>
-					<string>constant.numeric.date.month.beancount</string>
+					<string>punctuation.separator.beancount</string>
 				</dict>
 				<key>3</key>
 				<dict>
 					<key>name</key>
-					<string>constant.numeric.date.day.beancount</string>
+					<string>constant.numeric.date.month.beancount</string>
 				</dict>
 				<key>4</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.separator.beancount</string>
+				</dict>
+				<key>5</key>
+				<dict>
+					<key>name</key>
+					<string>constant.numeric.date.day.beancount</string>
+				</dict>
+				<key>6</key>
 				<dict>
 					<key>name</key>
 					<string>support.function.directive.beancount</string>
@@ -202,17 +226,21 @@
 			<array>
 				<dict>
 					<key>include</key>
+					<string>#meta</string>
+				</dict>
+				<dict>
+					<key>include</key>
 					<string>#string</string>
 				</dict>
 				<dict>
 					<key>include</key>
-					<string>#meta</string>
+					<string>#illegal</string>
 				</dict>
 			</array>
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>([0-9]{4})[\-|/]([0-9]{2})[\-|/]([0-9]{2})\s(commodity)</string>
+			<string>([0-9]{4})([\-|/])([0-9]{2})([\-|/])([0-9]{2})\s(commodity)</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>
@@ -223,14 +251,24 @@
 				<key>2</key>
 				<dict>
 					<key>name</key>
-					<string>constant.numeric.date.month.beancount</string>
+					<string>punctuation.separator.beancount</string>
 				</dict>
 				<key>3</key>
 				<dict>
 					<key>name</key>
-					<string>constant.numeric.date.day.beancount</string>
+					<string>constant.numeric.date.month.beancount</string>
 				</dict>
 				<key>4</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.separator.beancount</string>
+				</dict>
+				<key>5</key>
+				<dict>
+					<key>name</key>
+					<string>constant.numeric.date.day.beancount</string>
+				</dict>
+				<key>6</key>
 				<dict>
 					<key>name</key>
 					<string>support.function.directive.beancount</string>
@@ -246,17 +284,21 @@
 			<array>
 				<dict>
 					<key>include</key>
+					<string>#meta</string>
+				</dict>
+				<dict>
+					<key>include</key>
 					<string>#commodity</string>
 				</dict>
 				<dict>
 					<key>include</key>
-					<string>#meta</string>
+					<string>#illegal</string>
 				</dict>
 			</array>
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>([0-9]{4})[\-|/]([0-9]{2})[\-|/]([0-9]{2})\s(note|document)</string>
+			<string>([0-9]{4})([\-|/])([0-9]{2})([\-|/])([0-9]{2})\s(note|document)</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>
@@ -267,14 +309,24 @@
 				<key>2</key>
 				<dict>
 					<key>name</key>
-					<string>constant.numeric.date.month.beancount</string>
+					<string>punctuation.separator.beancount</string>
 				</dict>
 				<key>3</key>
 				<dict>
 					<key>name</key>
-					<string>constant.numeric.date.day.beancount</string>
+					<string>constant.numeric.date.month.beancount</string>
 				</dict>
 				<key>4</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.separator.beancount</string>
+				</dict>
+				<key>5</key>
+				<dict>
+					<key>name</key>
+					<string>constant.numeric.date.day.beancount</string>
+				</dict>
+				<key>6</key>
 				<dict>
 					<key>name</key>
 					<string>support.function.directive.beancount</string>
@@ -290,6 +342,10 @@
 			<array>
 				<dict>
 					<key>include</key>
+					<string>#meta</string>
+				</dict>
+				<dict>
+					<key>include</key>
 					<string>#account</string>
 				</dict>
 				<dict>
@@ -298,13 +354,13 @@
 				</dict>
 				<dict>
 					<key>include</key>
-					<string>#meta</string>
+					<string>#illegal</string>
 				</dict>
 			</array>
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>([0-9]{4})[\-|/]([0-9]{2})[\-|/]([0-9]{2})\s(price)</string>
+			<string>([0-9]{4})([\-|/])([0-9]{2})([\-|/])([0-9]{2})\s(price)</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>
@@ -315,14 +371,24 @@
 				<key>2</key>
 				<dict>
 					<key>name</key>
-					<string>constant.numeric.date.month.beancount</string>
+					<string>punctuation.separator.beancount</string>
 				</dict>
 				<key>3</key>
 				<dict>
 					<key>name</key>
-					<string>constant.numeric.date.day.beancount</string>
+					<string>constant.numeric.date.month.beancount</string>
 				</dict>
 				<key>4</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.separator.beancount</string>
+				</dict>
+				<key>5</key>
+				<dict>
+					<key>name</key>
+					<string>constant.numeric.date.day.beancount</string>
+				</dict>
+				<key>6</key>
 				<dict>
 					<key>name</key>
 					<string>support.function.directive.beancount</string>
@@ -338,6 +404,10 @@
 			<array>
 				<dict>
 					<key>include</key>
+					<string>#meta</string>
+				</dict>
+				<dict>
+					<key>include</key>
 					<string>#commodity</string>
 				</dict>
 				<dict>
@@ -346,13 +416,13 @@
 				</dict>
 				<dict>
 					<key>include</key>
-					<string>#meta</string>
+					<string>#illegal</string>
 				</dict>
 			</array>
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>([0-9]{4})[\-|/]([0-9]{2})[\-|/]([0-9]{2})\s(balance)</string>
+			<string>([0-9]{4})([\-|/])([0-9]{2})([\-|/])([0-9]{2})\s(balance)</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>
@@ -363,14 +433,24 @@
 				<key>2</key>
 				<dict>
 					<key>name</key>
-					<string>constant.numeric.date.month.beancount</string>
+					<string>punctuation.separator.beancount</string>
 				</dict>
 				<key>3</key>
 				<dict>
 					<key>name</key>
-					<string>constant.numeric.date.day.beancount</string>
+					<string>constant.numeric.date.month.beancount</string>
 				</dict>
 				<key>4</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.separator.beancount</string>
+				</dict>
+				<key>5</key>
+				<dict>
+					<key>name</key>
+					<string>constant.numeric.date.day.beancount</string>
+				</dict>
+				<key>6</key>
 				<dict>
 					<key>name</key>
 					<string>support.function.directive.beancount</string>
@@ -386,6 +466,10 @@
 			<array>
 				<dict>
 					<key>include</key>
+					<string>#meta</string>
+				</dict>
+				<dict>
+					<key>include</key>
 					<string>#account</string>
 				</dict>
 				<dict>
@@ -394,7 +478,7 @@
 				</dict>
 				<dict>
 					<key>include</key>
-					<string>#meta</string>
+					<string>#illegal</string>
 				</dict>
 			</array>
 		</dict>
@@ -454,6 +538,10 @@
 			<array>
 				<dict>
 					<key>include</key>
+					<string>#meta</string>
+				</dict>
+				<dict>
+					<key>include</key>
 					<string>#tag</string>
 				</dict>
 				<dict>
@@ -462,15 +550,15 @@
 				</dict>
 				<dict>
 					<key>include</key>
-					<string>#comment</string>
-				</dict>
-				<dict>
-					<key>include</key>
-					<string>#meta</string>
+					<string>#comments</string>
 				</dict>
 				<dict>
 					<key>include</key>
 					<string>#posting</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#illegal</string>
 				</dict>
 			</array>
 		</dict>
@@ -526,6 +614,10 @@
 							<key>include</key>
 							<string>$self</string>
 						</dict>
+						<dict>
+							<key>include</key>
+							<string>#illegal</string>
+						</dict>
 					</array>
 				</dict>
 			</array>
@@ -547,7 +639,7 @@
 				<key>3</key>
 				<dict>
 					<key>name</key>
-					<string>variable.other.currency.beancount</string>
+					<string>entity.type.commodity.beancount</string>
 				</dict>
 			</dict>
 			<key>match</key>
@@ -555,7 +647,7 @@
 			<key>name</key>
 			<string>meta.amount.beancount</string>
 		</dict>
-		<key>comment</key>
+		<key>comments</key>
 		<dict>
 			<key>captures</key>
 			<dict>
@@ -573,7 +665,7 @@
 			<key>match</key>
 			<string>([A-Z][A-Z0-9\'\.\_\-]{0,22}[A-Z0-9])</string>
 			<key>name</key>
-			<string>string.unquoted.commodity.beancount</string>
+			<string>entity.type.commodity.beancount</string>
 		</dict>
 		<key>cost</key>
 		<dict>
@@ -603,11 +695,21 @@
 			<array>
 				<dict>
 					<key>include</key>
-					<string>#date</string>
+					<string>#amount</string>
 				</dict>
 				<dict>
 					<key>include</key>
-					<string>#amount</string>
+					<string>#date</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>\,</string>
+					<key>name</key>
+					<string>punctuation.separator.beancount</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#illegal</string>
 				</dict>
 			</array>
 		</dict>
@@ -707,7 +809,11 @@
 				</dict>
 				<dict>
 					<key>include</key>
-					<string>#comment</string>
+					<string>#comments</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#illegal</string>
 				</dict>
 			</array>
 		</dict>
@@ -747,7 +853,7 @@
 				</dict>
 				<dict>
 					<key>include</key>
-					<string>#comment</string>
+					<string>#comments</string>
 				</dict>
 				<dict>
 					<key>include</key>
@@ -776,6 +882,10 @@
 				<dict>
 					<key>include</key>
 					<string>#amount</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#illegal</string>
 				</dict>
 			</array>
 		</dict>

--- a/beancount.tmLanguage
+++ b/beancount.tmLanguage
@@ -19,7 +19,9 @@
 			<string>comment.line.beancount</string>
 		</dict>
 		<dict>
-			<key>captures</key>
+			<key>begin</key>
+			<string>([A-Z][A-Za-z0-9\-]+)(:)</string>
+			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>
 				<dict>
@@ -33,45 +35,59 @@
 				</dict>
 			</dict>
 			<key>comment</key>
-			<string>Root Accounts</string>
-			<key>match</key>
-			<string>\s([A-Z][A-Za-z0-9\-]+)(:)</string>
-		</dict>
-		<dict>
-			<key>begin</key>
-			<string>([:]?)([A-Z][A-Za-z0-9\-]+)</string>
-			<key>beginCaptures</key>
-			<dict>
-				<key>1</key>
-				<dict>
-					<key>name</key>
-					<string>punctuation.separator.beancount</string>
-				</dict>
-				<key>2</key>
-				<dict>
-					<key>name</key>
-					<string>variable.account.beancount</string>
-				</dict>
-			</dict>
-			<key>comment</key>
-			<string>Accounts</string>
+			<string>Account</string>
 			<key>end</key>
-			<string>([:]?)|(\s)</string>
+			<string>\s</string>
 			<key>patterns</key>
 			<array>
 				<dict>
-					<key>include</key>
-					<string>$self</string>
+					<key>begin</key>
+					<string>([A-Z][A-Za-z0-9\-]+)([:]?)</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>variable.account.beancount</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.separator.beancount</string>
+						</dict>
+					</dict>
+					<key>comment</key>
+					<string>Sub accounts</string>
+					<key>end</key>
+					<string>([:]?)|(\s)</string>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>include</key>
+							<string>$self</string>
+						</dict>
+					</array>
 				</dict>
 			</array>
 		</dict>
 		<dict>
+			<key>begin</key>
+			<string>\"</string>
 			<key>comment</key>
 			<string>strings</string>
-			<key>match</key>
-			<string>\".*\"</string>
+			<key>end</key>
+			<string>\"</string>
 			<key>name</key>
 			<string>string.quoted.double.beancount</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>match</key>
+					<string>\\.</string>
+					<key>name</key>
+					<string>constant.character.escape.beancount</string>
+				</dict>
+			</array>
 		</dict>
 		<dict>
 			<key>captures</key>
@@ -103,17 +119,9 @@
 			<key>comment</key>
 			<string>Directives (no date)</string>
 			<key>match</key>
-			<string>^(poptag|pushtag)\s</string>
+			<string>^(poptag|pushtag|include|plugin)\s</string>
 			<key>name</key>
 			<string>keyword.operator.directive.beancount</string>
-		</dict>
-		<dict>
-			<key>comment</key>
-			<string>Currencies</string>
-			<key>match</key>
-			<string>\s([A-Z][A-Z0-9\'\.\_\-]{0,10}[A-Z0-9])[\,?|\s]</string>
-			<key>name</key>
-			<string>variable.other.currency.beancount</string>
 		</dict>
 		<dict>
 			<key>captures</key>
@@ -142,59 +150,33 @@
 			<key>comment</key>
 			<string>Dated directives</string>
 			<key>match</key>
-			<string>([0-9]{4})\-([0-9]{2})\-([0-9]{2})\s(open|close|pad|balance|note|price|event|document)</string>
+			<string>([0-9]{4})[\-|/]([0-9]{2})[\-|/]([0-9]{2})\s(open|close|pad|balance|note|price|event|document|commodity)</string>
 		</dict>
 		<dict>
-			<key>begin</key>
-			<string>([0-9]{4})\-([0-9]{2})\-([0-9]{2})(\stxn)?\s</string>
-			<key>beginCaptures</key>
+			<key>comment</key>
+			<string>metadata</string>
+			<key>match</key>
+			<string>\s\s([a-z][A-Za-z0-9\-]+)[:]\s</string>
+			<key>name</key>
+			<string>keyword.operator.directive.beancount</string>
+		</dict>
+		<dict>
+			<key>captures</key>
 			<dict>
 				<key>1</key>
 				<dict>
 					<key>name</key>
-					<string>constant.numeric.date.year.beancount</string>
+					<string>constant.numeric.date.beancount</string>
 				</dict>
 				<key>2</key>
-				<dict>
-					<key>name</key>
-					<string>constant.numeric.date.month.beancount</string>
-				</dict>
-				<key>3</key>
-				<dict>
-					<key>name</key>
-					<string>constant.numeric.date.day.beancount</string>
-				</dict>
-				<key>4</key>
 				<dict>
 					<key>name</key>
 					<string>support.function.directive.beancount</string>
 				</dict>
-			</dict>
-			<key>comment</key>
-			<string>Transactions</string>
-			<key>end</key>
-			<string>\s(".*")\s(\|)\s(".*")|\s(".*")\s(".*")|(".*")[\s]*$|([\s]*$)</string>
-			<key>endCaptures</key>
-			<dict>
-				<key>1</key>
-				<dict>
-					<key>name</key>
-					<string>meta.structure.dictionary.payee.beancount</string>
-				</dict>
-				<key>2</key>
-				<dict>
-					<key>name</key>
-					<string>invalid.deprecated.separator.beancount</string>
-				</dict>
-				<key>3</key>
-				<dict>
-					<key>name</key>
-					<string>string.quoted.narration.beancount</string>
-				</dict>
 				<key>4</key>
 				<dict>
 					<key>name</key>
-					<string>meta.structure.dictionary.payee.beancount</string>
+					<string>string.quoted.tiers.beancount</string>
 				</dict>
 				<key>5</key>
 				<dict>
@@ -204,30 +186,24 @@
 				<key>6</key>
 				<dict>
 					<key>name</key>
-					<string>string.quoted.narration.beancount</string>
+					<string>keyword.operator.tags.beancount</string>
+				</dict>
+				<key>8</key>
+				<dict>
+					<key>name</key>
+					<string>comment.line.beancount</string>
 				</dict>
 			</dict>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>match</key>
-					<string>\!</string>
-					<key>name</key>
-					<string>keyword.operator.flag.beancount</string>
-				</dict>
-				<dict>
-					<key>match</key>
-					<string>\*</string>
-					<key>name</key>
-					<string>keyword.operator.mark.beancount</string>
-				</dict>
-			</array>
+			<key>comment</key>
+			<string>Transactions</string>
+			<key>match</key>
+			<string>([0-9]{4}[\-|/][0-9]{2}[\-|/][0-9]{2})\s((txn)|\*|\!)\s(".*?")(\s+".*?")?((\s*#[a-zA-z\-]+)*)(\s*;.*)?</string>
 		</dict>
 		<dict>
 			<key>comment</key>
 			<string>flag</string>
 			<key>match</key>
-			<string>\!\s</string>
+			<string>\s\!</string>
 			<key>name</key>
 			<string>keyword.other.beancount</string>
 		</dict>
@@ -275,6 +251,11 @@
 		<dict>
 			<key>captures</key>
 			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>keyword.operator.tag.beancount</string>
+				</dict>
 				<key>2</key>
 				<dict>
 					<key>name</key>
@@ -313,11 +294,16 @@
 					<key>name</key>
 					<string>constant.numeric.currency.beancount</string>
 				</dict>
+				<key>3</key>
+				<dict>
+					<key>name</key>
+					<string>variable.other.currency.beancount</string>
+				</dict>
 			</dict>
 			<key>comment</key>
 			<string>numbers</string>
 			<key>match</key>
-			<string>([\-|\+]?)([\d]+[\.]?[\d]*)</string>
+			<string>([\-|\+]?)([\d]+[\.]?[\d]*)\s?([A-Z][A-Z0-9\-]{0,10})</string>
 		</dict>
 		<dict>
 			<key>comment</key>
@@ -328,65 +314,6 @@
 			<string>invalid.illegal.unrecognized.beancount</string>
 		</dict>
 	</array>
-	<key>repository</key>
-	<dict>
-		<key>account-names</key>
-		<dict>
-			<key>match</key>
-			<string>([A-Z][A-Za-z0-9\-]+)</string>
-		</dict>
-		<key>dates</key>
-		<dict>
-			<key>captures</key>
-			<dict>
-				<key>1</key>
-				<dict>
-					<key>name</key>
-					<string>constant.numeric.date.year.beancount</string>
-				</dict>
-				<key>2</key>
-				<dict>
-					<key>name</key>
-					<string>punctuation.separator.beancount</string>
-				</dict>
-				<key>3</key>
-				<dict>
-					<key>name</key>
-					<string>constant.numeric.date.month.beancount</string>
-				</dict>
-				<key>4</key>
-				<dict>
-					<key>name</key>
-					<string>punctuation.separator.beancount</string>
-				</dict>
-				<key>5</key>
-				<dict>
-					<key>name</key>
-					<string>constant.numeric.date.day.beancount</string>
-				</dict>
-			</dict>
-			<key>match</key>
-			<string>([0-9]{4})(\-)([0-9]{2})(\-)([0-9]{2})</string>
-		</dict>
-		<key>numbers</key>
-		<dict>
-			<key>captures</key>
-			<dict>
-				<key>1</key>
-				<dict>
-					<key>name</key>
-					<string>keyword.operator.modifier.beancount</string>
-				</dict>
-				<key>2</key>
-				<dict>
-					<key>name</key>
-					<string>constant.numeric.currency.beancount</string>
-				</dict>
-			</dict>
-			<key>match</key>
-			<string>([\-|\+]?)([\d]+[\.]?[\d]*)</string>
-		</dict>
-	</dict>
 	<key>scopeName</key>
 	<string>source.beancount</string>
 	<key>uuid</key>


### PR DESCRIPTION
Fixed/Improved:
* DRY
* multiline directives are now recognized correctly
* highlight (almost) only when syntax is correct
* add support for plugin
* More accurate regex, 
* Whitespace is now handled more closer to `bean-check`
* un-hardcore support for meta strings
* more colors
* consistent matching of dates and tags

And most probably new bugs has been made, but overall I think it looks better. 