### PR TITLE
Set comment character and improved syntax matching

### DIFF
--- a/beancount.YAML-tmLanguage
+++ b/beancount.YAML-tmLanguage
@@ -9,39 +9,51 @@ patterns:
   match: ;.*
 - comment: Tag directive
   name: meta.directive.tag.beancount
-  match: ^(poptag|pushtag)\s+(#)([A-Za-z0-9\-_/.]+)\s+(;.*)\s*\n
-  captures:
+  begin: ^(poptag|pushtag)\s+(#)([A-Za-z0-9\-_/.]+)
+  beginCaptures:
     '1': {name: support.function.beancount}
     '2': {name: keyword.operator.tag.beancount}
     '3': {name: entity.name.tag.beancount}
-    '4': {name: comment.line.beancount}
+  end: (?=(^\s*$|^\S))
+  patterns:
+  - include: '#comments'
+  - include: '#illegal'
 - comment: Include directive
   name: meta.directive.include.beancount
-  match: ^(include)\s+(\".*\")\s*\n
-  captures:
+  begin: ^(include)\s+(\".*\")
+  beginCaptures:
     '1': {name: support.function.beancount}
     '2': {name: string.quoted.double.beancount}
-    '3': {name: comment.line.beancount}
+  end: (?=(^\s*$|^\S))
+  patterns:
+  - include: '#comments'
+  - include: '#illegal'
 - comment: Option directive
   name: meta.directive.option.beancount
-  match: ^(option)\s+(\".*\")\s+(\".*\")\s+(;.*)\s*\n
-  captures:
+  begin: ^(option)\s+(\".*\")\s+(\".*\")
+  beginCaptures:
     '1': {name: support.function.beancount}
     '2': {name: support.variable.beancount}
     '3': {name: string.quoted.double.beancount}
-    '4': {name: comment.line.beancount}
+  end: (?=(^\s*$|^\S))
+  patterns:
+  - include: '#comments'
+  - include: '#illegal'
 - comment: Plugin directive
   name: keyword.operator.directive.beancount
-  match: ^(plugin)\s+(\"(.*)\")\s+(\".*\")\s+(;.*)\s*\n
-  captures:
+  begin: ^(plugin)\s+(\"(.*)\")\s+(\".*\")
+  beginCaptures:
     '1': {name: support.function.beancount}
     '2': {name: string.quoted.double.beancount}
     '3': {name: entity.name.function.beancount}
     '4': {name: string.quoted.double.beancount}
-    '5': {name: comment.line.beancount}
+  end: (?=(^\s*$|^\S))
+  patterns:
+  - include: '#comments'
+  - include: '#illegal'
 - comment: Open/Close/Pad directive
   name: meta.directive.dated.beancount
-  begin: ([0-9]{4})([\-|/])([0-9]{2})([\-|/])([0-9]{2})\s(open|close|pad)
+  begin: ([0-9]{4})([\-|/])([0-9]{2})([\-|/])([0-9]{2})\s+(open|close|pad)
   beginCaptures:
     '1': {name: constant.numeric.date.year.beancount}
     '2': {name: punctuation.separator.beancount}
@@ -54,6 +66,9 @@ patterns:
   - include: '#comments'
   - include: '#meta'
   - include: '#account'
+  - include: '#commodity'
+  - name: punctuation.separator.beancount
+    match: \,
   - include: '#illegal'
 - comment: Event directive
   name: meta.directive.dated.beancount
@@ -178,7 +193,7 @@ repository:
       - include: '#illegal'
   amount:
     name: meta.amount.beancount
-    match: ([\-|\+]?)([\d]+[\.]?[\d]*)\s*([A-Z][A-Z0-9\'\.\_\-]{0,22}[A-Z0-9])
+    match: ([\-|\+]?)((?:\d|\d[\d,]*\d)(?:\.\d*)?)\s*([A-Z][A-Z0-9\'\.\_\-]{0,22}[A-Z0-9])
     captures:
       '1': {name: keyword.operator.modifier.beancount}
       '2': {name: constant.numeric.currency.beancount}
@@ -192,10 +207,10 @@ repository:
     match: ([A-Z][A-Z0-9\'\.\_\-]{0,22}[A-Z0-9])
   cost:
     name: meta.cost.beancount
-    begin: \{
+    begin: \{\{?
     beginCaptures:
       '0': {name: keyword.operator.assignment.beancount}
-    end: \}
+    end: \}\}?
     endCaptures:
       '0': {name: keyword.operator.assignment.beancount}
     patterns:

--- a/beancount.tmLanguage
+++ b/beancount.tmLanguage
@@ -19,7 +19,9 @@
 			<string>comment.line.beancount</string>
 		</dict>
 		<dict>
-			<key>captures</key>
+			<key>begin</key>
+			<string>^(poptag|pushtag)\s+(#)([A-Za-z0-9\-_/.]+)</string>
+			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>
 				<dict>
@@ -36,21 +38,29 @@
 					<key>name</key>
 					<string>entity.name.tag.beancount</string>
 				</dict>
-				<key>4</key>
-				<dict>
-					<key>name</key>
-					<string>comment.line.beancount</string>
-				</dict>
 			</dict>
 			<key>comment</key>
 			<string>Tag directive</string>
-			<key>match</key>
-			<string>^(poptag|pushtag)\s+(#)([A-Za-z0-9\-_/.]+)\s+(;.*)\s*\n</string>
+			<key>end</key>
+			<string>(?=(^\s*$|^\S))</string>
 			<key>name</key>
 			<string>meta.directive.tag.beancount</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>#comments</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#illegal</string>
+				</dict>
+			</array>
 		</dict>
 		<dict>
-			<key>captures</key>
+			<key>begin</key>
+			<string>^(include)\s+(\".*\")</string>
+			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>
 				<dict>
@@ -62,21 +72,29 @@
 					<key>name</key>
 					<string>string.quoted.double.beancount</string>
 				</dict>
-				<key>3</key>
-				<dict>
-					<key>name</key>
-					<string>comment.line.beancount</string>
-				</dict>
 			</dict>
 			<key>comment</key>
 			<string>Include directive</string>
-			<key>match</key>
-			<string>^(include)\s+(\".*\")\s*\n</string>
+			<key>end</key>
+			<string>(?=(^\s*$|^\S))</string>
 			<key>name</key>
 			<string>meta.directive.include.beancount</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>#comments</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#illegal</string>
+				</dict>
+			</array>
 		</dict>
 		<dict>
-			<key>captures</key>
+			<key>begin</key>
+			<string>^(option)\s+(\".*\")\s+(\".*\")</string>
+			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>
 				<dict>
@@ -93,21 +111,29 @@
 					<key>name</key>
 					<string>string.quoted.double.beancount</string>
 				</dict>
-				<key>4</key>
-				<dict>
-					<key>name</key>
-					<string>comment.line.beancount</string>
-				</dict>
 			</dict>
 			<key>comment</key>
 			<string>Option directive</string>
-			<key>match</key>
-			<string>^(option)\s+(\".*\")\s+(\".*\")\s+(;.*)\s*\n</string>
+			<key>end</key>
+			<string>(?=(^\s*$|^\S))</string>
 			<key>name</key>
 			<string>meta.directive.option.beancount</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>#comments</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#illegal</string>
+				</dict>
+			</array>
 		</dict>
 		<dict>
-			<key>captures</key>
+			<key>begin</key>
+			<string>^(plugin)\s+(\"(.*)\")\s+(\".*\")</string>
+			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>
 				<dict>
@@ -129,22 +155,28 @@
 					<key>name</key>
 					<string>string.quoted.double.beancount</string>
 				</dict>
-				<key>5</key>
-				<dict>
-					<key>name</key>
-					<string>comment.line.beancount</string>
-				</dict>
 			</dict>
 			<key>comment</key>
 			<string>Plugin directive</string>
-			<key>match</key>
-			<string>^(plugin)\s+(\"(.*)\")\s+(\".*\")\s+(;.*)\s*\n</string>
+			<key>end</key>
+			<string>(?=(^\s*$|^\S))</string>
 			<key>name</key>
 			<string>keyword.operator.directive.beancount</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>#comments</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#illegal</string>
+				</dict>
+			</array>
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>([0-9]{4})([\-|/])([0-9]{2})([\-|/])([0-9]{2})\s(open|close|pad)</string>
+			<string>([0-9]{4})([\-|/])([0-9]{2})([\-|/])([0-9]{2})\s+(open|close|pad)</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>
@@ -197,6 +229,16 @@
 				<dict>
 					<key>include</key>
 					<string>#account</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#commodity</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>\,</string>
+					<key>name</key>
+					<string>punctuation.separator.beancount</string>
 				</dict>
 				<dict>
 					<key>include</key>
@@ -687,7 +729,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>([\-|\+]?)([\d]+[\.]?[\d]*)\s*([A-Z][A-Z0-9\'\.\_\-]{0,22}[A-Z0-9])</string>
+			<string>([\-|\+]?)((?:\d|\d[\d,]*\d)(?:\.\d*)?)\s*([A-Z][A-Z0-9\'\.\_\-]{0,22}[A-Z0-9])</string>
 			<key>name</key>
 			<string>meta.amount.beancount</string>
 		</dict>
@@ -714,7 +756,7 @@
 		<key>cost</key>
 		<dict>
 			<key>begin</key>
-			<string>\{</string>
+			<string>\{\{?</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>0</key>
@@ -724,7 +766,7 @@
 				</dict>
 			</dict>
 			<key>end</key>
-			<string>\}</string>
+			<string>\}\}?</string>
 			<key>endCaptures</key>
 			<dict>
 				<key>0</key>

--- a/beancount.tmPreferences
+++ b/beancount.tmPreferences
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>name</key>
+	<string>Beancount</string>
+	<key>scope</key>
+	<string>source.beancount</string>
+	<key>settings</key>
+	<dict>
+		<key>shellVariables</key>
+		<array>
+			<dict>
+				<key>name</key>
+				<string>TM_COMMENT_START</string>
+				<key>value</key>
+				<string>; </string>
+			</dict>
+		</array>
+	</dict>
+</dict>
+</plist>


### PR DESCRIPTION
Setting the comment character makes it possible to comment and uncomment selected lines using Ctrl+/.

This also fixes some overly prescriptive regexes, such as required comments after `option` directives, and it adds support for a broader range of valid syntax, most notably comma separators in numbers (e.g. `1,234.00`) and currency/commodity restrictions on `open` directives (e.g. `2017-02-16 open Assets:Checking USD`).