### PR TITLE
Allow all possible flags

### DIFF
--- a/beancount.YAML-tmLanguage
+++ b/beancount.YAML-tmLanguage
@@ -155,7 +155,7 @@ patterns:
   - include: '#illegal'
 - comment: Transaction directive
   name: meta.directive.transaction.beancount
-  begin: ([0-9]{4})([\-|/])([0-9]{2})([\-|/])([0-9]{2})\s+(txn|\*|\!)(?:\s+(".*")(?=\s+"))?\s+(".*?")(?=((?:\s+#[a-zA-z\-]+(?=\s))*(?:\s+\^[a-zA-z\-\.]+(?=\s))*(?:\s+;\s*.*)?)\s)
+  begin: ([0-9]{4})([\-|/])([0-9]{2})([\-|/])([0-9]{2})\s+(txn|[*!&amp;#?%PSTCURM])(?:\s+(".*")(?=\s+"))?\s+(".*?")(?=((?:\s+#[a-zA-z\-]+(?=\s))*(?:\s+\^[a-zA-z\-\.]+(?=\s))*(?:\s+;\s*.*)?)\s)
   beginCaptures:
     '1': {name: constant.numeric.date.year.beancount}
     '2': {name: punctuation.separator.beancount}
@@ -230,7 +230,7 @@ repository:
       '5': {name: constant.numeric.date.day.beancount}
   flag:
     name: keyword.other.beancount
-    match: (?<=\s)(\!)
+    match: (?<=\s)([*!&amp;#?%PSTCURM])
   illegal:
     name: invalid.illegal.unrecognized.beancount
     match: '[^\s]'


### PR DESCRIPTION
As per https://bitbucket.org/blais/beancount/src/tip/src/python/beancount/parser/lexer.l?fileviewer=file-view-default#lexer.l-191

I'm assuming that beancount.tmLanguage is generated from beancount.YAML-tmLanguage.  There are no instructions nor a Makefile to build this file, so I'll leave that to whoever pulls this change in.